### PR TITLE
Resolve deep links fix

### DIFF
--- a/ios/Plugin/AppsFlyerPlugin.swift
+++ b/ios/Plugin/AppsFlyerPlugin.swift
@@ -188,7 +188,7 @@ public class AppsFlyerPlugin: CAPPlugin {
         for url in arr {
             urls.append(url as! String)
         }
-        AppsFlyerLib.shared().oneLinkCustomDomains = urls
+        AppsFlyerLib.shared().resolveDeepLinkURLs = urls
         
     }
     


### PR DESCRIPTION
I think this is a copy-paste error. `setResolveDeepLinkURLs` should set `resolveDeepLinkURLs` and `setOneLinkCustomDomain` should set `oneLinkCustomDomains`.

Before this change, links in emails could not redirect to a location inside the app. With this change, they now can.