### PR TITLE
Update plugin + new API 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,7 +14,8 @@ xcuserdata
 # macOS files
 .DS_Store
 
-
+# Eclipse files
+.project
 
 # Based on Android gitignore template: https://github.com/github/gitignore/blob/HEAD/Android.gitignore
 

--- a/AppsflyerCapacitorPlugin.podspec
+++ b/AppsflyerCapacitorPlugin.podspec
@@ -11,7 +11,7 @@ Pod::Spec.new do |s|
   s.source = { :git => package['repository']['url'], :tag => s.version.to_s }
   s.source_files = 'ios/Plugin/**/*.{swift,h,m,c,cc,mm,cpp}'
   s.static_framework = true
-  s.ios.deployment_target  = '13.0'
+  s.ios.deployment_target  = '14.0'
   s.dependency 'Capacitor'
   s.swift_version = '5.1'
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 6.17.0
+- Upgraded AppsFlyer Android SDK to v6.17.0
+- Upgraded AppsFlyer iOS SDK to v6.17.0
+- Added new Android API `disableAppSetId()` to prevent collection of the Android AppSet ID
+- Updated to support Capacitor v7
+
 ## 6.16.2
  Release date: *2025-03-26*
 

--- a/README.md
+++ b/README.md
@@ -14,8 +14,9 @@
 
 ### <a id="plugin-build-for"> This plugin is built for
 
-- Android AppsFlyer SDK **6.17.0**
-- iOS AppsFlyer SDK **6.17.0**
+- <img src="https://raw.githubusercontent.com/github/explore/80688e429a7d4ef2fca1e82350fe8e3517d3494d/topics/android/android.png" width="18" height="18"> Android AppsFlyer SDK **6.17.0**
+- <img src="https://raw.githubusercontent.com/github/explore/80688e429a7d4ef2fca1e82350fe8e3517d3494d/topics/ios/ios.png" width="18" height="18"> iOS AppsFlyer SDK **6.17.0**
+- <img src="https://user-images.githubusercontent.com/236501/105104854-e5e42e80-5a67-11eb-8cb8-46fccb079062.png" width="18" height="18"> Capacitor 7
 
 ## <a id="breaking-changes-6-17-0"> 	❗❗ Breaking changes when updating to v6.17.0 ❗❗
 Starting from v6.17.0, this plugin works only with Capacitor 7. </br>

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 ### <a id="plugin-build-for"> This plugin is built for:
 
 <img src="https://raw.githubusercontent.com/github/explore/80688e429a7d4ef2fca1e82350fe8e3517d3494d/topics/android/android.png" width="18" height="18">  Android AppsFlyer SDK **6.17.0**</br>
-<img src="https://raw.githubusercontent.com/github/explore/80688e429a7d4ef2fca1e82350fe8e3517d3494d/topics/ios/ios.png" width="18" height="18">  iOS AppsFlyer SDK **6.17.0**</br>
+<img src="https://icon.icepanel.io/Technology/svg/Apple.svg" width="18" height="18">  iOS AppsFlyer SDK **6.17.0**</br>
 <img src="https://icon.icepanel.io/Technology/svg/Capacitor.svg" width="18" height="18">  Capacitor 7</br>
 
 ## <a id="breaking-changes-6-17-0"> 	❗❗ Breaking changes when updating to v6.17.0 ❗❗

--- a/README.md
+++ b/README.md
@@ -14,8 +14,12 @@
 
 ### <a id="plugin-build-for"> This plugin is built for
 
-- Android AppsFlyer SDK **6.16.2**
-- iOS AppsFlyer SDK **6.16.2**
+- Android AppsFlyer SDK **6.17.0**
+- iOS AppsFlyer SDK **6.17.0**
+
+## <a id="breaking-changes-6-17-0"> 	❗❗ Breaking changes when updating to v6.17.0 ❗❗
+Starting from v6.17.0, this plugin works only with Capacitor 7. </br>
+If you are still interested in using Capacitor 6, please follow the instructions [here](/docs/Installation.md#cap6) to install the latest version that supports Capacitor 6.
 
 ## <a id="breaking-changes-6-15-0"> 	❗❗ Breaking changes when updating to v6.15.0 ❗❗
 Starting from v6.15.0, this plugin works only with Capacitor 6. </br>

--- a/README.md
+++ b/README.md
@@ -12,11 +12,11 @@
 > *When submitting an issue please specify your AppsFlyer sign-up (account) email , your app ID , production steps, logs, code snippets and any additional relevant information.*
 
 
-### <a id="plugin-build-for"> This plugin is built for
+### <a id="plugin-build-for"> This plugin is built for:
 
-- <img src="https://raw.githubusercontent.com/github/explore/80688e429a7d4ef2fca1e82350fe8e3517d3494d/topics/android/android.png" width="18" height="18"> Android AppsFlyer SDK **6.17.0**
-- <img src="https://raw.githubusercontent.com/github/explore/80688e429a7d4ef2fca1e82350fe8e3517d3494d/topics/ios/ios.png" width="18" height="18"> iOS AppsFlyer SDK **6.17.0**
-- <img src="https://icon.icepanel.io/Technology/svg/Capacitor.svg" width="18" height="18"> Capacitor 7
+<img src="https://raw.githubusercontent.com/github/explore/80688e429a7d4ef2fca1e82350fe8e3517d3494d/topics/android/android.png" width="18" height="18">  Android AppsFlyer SDK **6.17.0**</br>
+<img src="https://raw.githubusercontent.com/github/explore/80688e429a7d4ef2fca1e82350fe8e3517d3494d/topics/ios/ios.png" width="18" height="18">  iOS AppsFlyer SDK **6.17.0**</br>
+<img src="https://icon.icepanel.io/Technology/svg/Capacitor.svg" width="18" height="18">  Capacitor 7</br>
 
 ## <a id="breaking-changes-6-17-0"> 	❗❗ Breaking changes when updating to v6.17.0 ❗❗
 Starting from v6.17.0, this plugin works only with Capacitor 7. </br>

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 
 - <img src="https://raw.githubusercontent.com/github/explore/80688e429a7d4ef2fca1e82350fe8e3517d3494d/topics/android/android.png" width="18" height="18"> Android AppsFlyer SDK **6.17.0**
 - <img src="https://raw.githubusercontent.com/github/explore/80688e429a7d4ef2fca1e82350fe8e3517d3494d/topics/ios/ios.png" width="18" height="18"> iOS AppsFlyer SDK **6.17.0**
-- <img src="https://seeklogo.com/images/C/capacitor-logo-DF3634DD70-seeklogo.com.png" width="18" height="18"> Capacitor 7
+- <img src="https://icon.icepanel.io/Technology/svg/Capacitor.svg" width="18" height="18"> Capacitor 7
 
 ## <a id="breaking-changes-6-17-0"> 	❗❗ Breaking changes when updating to v6.17.0 ❗❗
 Starting from v6.17.0, this plugin works only with Capacitor 7. </br>

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 
 - <img src="https://raw.githubusercontent.com/github/explore/80688e429a7d4ef2fca1e82350fe8e3517d3494d/topics/android/android.png" width="18" height="18"> Android AppsFlyer SDK **6.17.0**
 - <img src="https://raw.githubusercontent.com/github/explore/80688e429a7d4ef2fca1e82350fe8e3517d3494d/topics/ios/ios.png" width="18" height="18"> iOS AppsFlyer SDK **6.17.0**
-- <img src="https://user-images.githubusercontent.com/236501/105104854-e5e42e80-5a67-11eb-8cb8-46fccb079062.png" width="18" height="18"> Capacitor 7
+- <img src="https://seeklogo.com/images/C/capacitor-logo-DF3634DD70-seeklogo.com.png" width="18" height="18"> Capacitor 7
 
 ## <a id="breaking-changes-6-17-0"> 	❗❗ Breaking changes when updating to v6.17.0 ❗❗
 Starting from v6.17.0, this plugin works only with Capacitor 7. </br>

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -129,22 +129,22 @@ ext {
     packageJson = getPackageJson()
 
     junitVersion = project.hasProperty('junitVersion') ? rootProject.ext.junitVersion : '4.13.2'
-    androidxAppCompatVersion = project.hasProperty('androidxAppCompatVersion') ? rootProject.ext.androidxAppCompatVersion : '1.6.1'
-    androidxJunitVersion = project.hasProperty('androidxJunitVersion') ? rootProject.ext.androidxJunitVersion : '1.1.5'
-    androidxEspressoCoreVersion = project.hasProperty('androidxEspressoCoreVersion') ? rootProject.ext.androidxEspressoCoreVersion : '3.5.1'
+    androidxAppCompatVersion = project.hasProperty('androidxAppCompatVersion') ? rootProject.ext.androidxAppCompatVersion : '1.7.0'
+    androidxJunitVersion = project.hasProperty('androidxJunitVersion') ? rootProject.ext.androidxJunitVersion : '1.2.1'
+    androidxEspressoCoreVersion = project.hasProperty('androidxEspressoCoreVersion') ? rootProject.ext.androidxEspressoCoreVersion : '3.6.1'
     af_sdk_version = packageJson?.androidSdkVersion
     plugin_version = packageJson?.version
     plugin_build_version = packageJson?.buildNumber
 }
 
 buildscript {
-    ext.kotlin_version = project.hasProperty("kotlin_version") ? rootProject.ext.kotlin_version : '1.9.10'
+    ext.kotlin_version = project.hasProperty("kotlin_version") ? rootProject.ext.kotlin_version : '1.9.25'
     repositories {
         google()
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:8.2.1'
+        classpath 'com.android.tools.build:gradle:8.7.2'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath 'org.codehaus.groovy:groovy-json:3.0.9'
     }
@@ -155,10 +155,10 @@ apply plugin: 'kotlin-android'
 
 android {
     namespace "capacitor.plugin.appsflyer.sdk"
-    compileSdk project.hasProperty('compileSdkVersion') ? rootProject.ext.compileSdkVersion : 34
+    compileSdk project.hasProperty('compileSdkVersion') ? rootProject.ext.compileSdkVersion : 35
     defaultConfig {
-        minSdkVersion project.hasProperty('minSdkVersion') ? rootProject.ext.minSdkVersion : 22
-        targetSdkVersion project.hasProperty('targetSdkVersion') ? rootProject.ext.targetSdkVersion : 34
+        minSdkVersion project.hasProperty('minSdkVersion') ? rootProject.ext.minSdkVersion : 23
+        targetSdkVersion project.hasProperty('targetSdkVersion') ? rootProject.ext.targetSdkVersion : 35
         versionCode Integer.parseInt(plugin_build_version)
         versionName "$plugin_version"
         buildConfigField "int", "VERSION_CODE", plugin_build_version
@@ -175,8 +175,8 @@ android {
         abortOnError false
     }
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_17
-        targetCompatibility JavaVersion.VERSION_17
+        sourceCompatibility JavaVersion.VERSION_21
+        targetCompatibility JavaVersion.VERSION_21
     }
     buildFeatures {
         buildConfig = true

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.2.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.11.1-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/android/src/main/java/capacitor/plugin/appsflyer/sdk/AppsFlyerPlugin.kt
+++ b/android/src/main/java/capacitor/plugin/appsflyer/sdk/AppsFlyerPlugin.kt
@@ -655,6 +655,12 @@ class AppsFlyerPlugin : Plugin() {
         call.resolve()
     }
 
+    @PluginMethod(returnType = PluginMethod.RETURN_NONE)
+    fun disableAppSetId(call: PluginCall) {
+        AppsFlyerLib.getInstance().disableAppSetId()
+        call.resolve()
+    }
+
     private fun getDeepLinkListener(): DeepLinkListener {
         return DeepLinkListener {
             if (udl == true) {

--- a/docs/API.md
+++ b/docs/API.md
@@ -63,6 +63,7 @@ The list of available methods for this plugin is described below.
 * [`setConsentDataV2`](#setConsentDataV2)  - Since 6.16.2
 * [`isSDKStarted`](#isSDKStarted)  - Since 6.16.2
 * [`isSDKStopped`](#isSDKStopped)  - Since 6.16.2
+* [`disableAppSetId`](#disableappsetid)  - Since 6.17.0
 
  
   
@@ -253,7 +254,7 @@ See also Log Event guide [here](/Guides.md#logevent).
 setCustomerUserId(cuid: AFCuid) => Promise<void>  
 ```  
   
-Setting your own customer ID enables you to cross-reference your own unique ID with AppsFlyer’s unique ID and other devices’ IDs.  
+Setting your own customer ID enables you to cross-reference your own unique ID with AppsFlyer's unique ID and other devices' IDs.  
 This ID is available in raw-data reports and in the Postback APIs for cross-referencing with your internal IDs.  
   
 | Param      | Type                                      |  
@@ -1091,6 +1092,25 @@ if your app doesn't use a CMP compatible with TCF v2.2, use the following method
 ``` 
 
 *Please take a look how to properly setConsentData Manualy in [Set Consent For DMA Compliance](/docs/DMA.md#)*
+
+--------------------  
+
+### disableAppSetId
+```typescript  
+disableAppSetId(): Promise<void>
+```  
+
+Disables AppSet ID collection. If called before SDK init, App Set ID will not be collected.
+If called after init, App Set ID will be collected but not sent in request payloads.
+Android only.
+
+**Returns:** <code>Promise<void></code>  
+
+```typescript  
+    AppsFlyer.disableAppSetId()
+      .then(res => console.log(res.res))
+      .catch(e => console.log(e));
+```  
 
 --------------------  
 

--- a/docs/Installation.md
+++ b/docs/Installation.md
@@ -8,6 +8,18 @@ The plugin available via npm. To install the plugin, please run the following co
  npx cap sync  
  ```
 
+## <a id="cap6"> Capacitor 6 - Latest Version
+The latest version that supports Capacitor 6 uses the following SDK versions:
+- Android AppsFlyer SDK **6.16.2**
+- iOS AppsFlyer SDK **6.16.2**
+
+The plugin available via npm under the tag `latest-6`. To install the plugin, please run the following commands in your project root directory.
+
+ ```bash  
+ npm install appsflyer-capacitor-plugin@latest-6
+ npx cap sync  
+ ```
+
 ## <a id="cap5"> Capacitor 5 - Latest Version
 The latest version that supports Capacitor 5 uses the following SDK versions:
 - Android AppsFlyer SDK **6.14.0**
@@ -22,8 +34,8 @@ The plugin available via npm under the tag `latest-5`. To install the plugin, pl
 
 ## <a id="cap4"> Capacitor 4 - Latest Version
 The latest version that supports Capacitor 4 uses the following SDK versions:
-- Android AppsFlyer SDK **6.10.3️**
-- iOS AppsFlyer SDK **6.10.1️**
+- Android AppsFlyer SDK **6.10.3**
+- iOS AppsFlyer SDK **6.10.1**
 
 The plugin available via npm under the tag `latest-4`. To install the plugin, please run the following commands in your project root directory.
 
@@ -35,8 +47,8 @@ The plugin available via npm under the tag `latest-4`. To install the plugin, pl
 
 ## <a id="cap3"> Capacitor 3 - Latest Version
 The latest version that supports Capacitor 3 uses the following SDK versions: 
-- Android AppsFlyer SDK **6.9.2️**
-- iOS AppsFlyer SDK **6.8.1️**
+- Android AppsFlyer SDK **6.9.2**
+- iOS AppsFlyer SDK **6.8.1**
 
 The plugin available via npm under the tag `latest-3`. To install the plugin, please run the following commands in your project root directory.
 

--- a/examples/CapacitorReact/package.json
+++ b/examples/CapacitorReact/package.json
@@ -3,13 +3,13 @@
   "version": "0.0.1",
   "private": true,
   "dependencies": {
-    "@capacitor/android": "^6.0.0",
-    "@capacitor/app": "^6.0.0",
-    "@capacitor/core": "^6.0.0",
-    "@capacitor/haptics": "^6.0.0",
-    "@capacitor/ios": "^6.0.0",
-    "@capacitor/keyboard": "^6.0.0",
-    "@capacitor/status-bar": "^6.0.0",
+    "@capacitor/android": "^7.0.0",
+    "@capacitor/app": "^7.0.0",
+    "@capacitor/core": "^7.0.0",
+    "@capacitor/haptics": "^7.0.0",
+    "@capacitor/ios": "^7.0.0",
+    "@capacitor/keyboard": "^7.0.0",
+    "@capacitor/status-bar": "^7.0.0",
     "@ionic/react": "^5.5.0",
     "@ionic/react-router": "^5.5.0",
     "@testing-library/jest-dom": "^5.11.9",
@@ -80,7 +80,7 @@
     ]
   },
   "devDependencies": {
-    "@capacitor/cli": "^6.0.0"
+    "@capacitor/cli": "^7.0.0"
   },
   "description": "An Ionic project"
 }

--- a/ios/Plugin/AppsFlyerPlugin.swift
+++ b/ios/Plugin/AppsFlyerPlugin.swift
@@ -5,7 +5,7 @@ import AppsFlyerLib
 
 @objc(AppsFlyerPlugin)
 public class AppsFlyerPlugin: CAPPlugin {
-    private let APPSFLYER_PLUGIN_VERSION = "6.16.2"
+    private let APPSFLYER_PLUGIN_VERSION = "6.17.0"
     private var conversion = true
     private var oaoa = true
     private var udl = false

--- a/ios/Podfile
+++ b/ios/Podfile
@@ -1,4 +1,4 @@
-platform :ios, '13.0'
+platform :ios, '14.0'
 
 def capacitor_pods
   # Comment the next line if you're not using Swift and don't want to use dynamic frameworks

--- a/ios/Podfile
+++ b/ios/Podfile
@@ -10,7 +10,7 @@ end
 
 target 'Plugin' do
   capacitor_pods
-    pod 'AppsFlyerFramework', ' 6.16.2'
+    pod 'AppsFlyerFramework', ' 6.17.0'
 end
 
 target 'PluginTests' do

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "typescript": "~4.0.3"
   },
   "peerDependencies": {
-    "@capacitor/core": "^7.0.0"
+    "@capacitor/core": ">=7.0.0"
   },
   "prettier": "@ionic/prettier-config",
   "swiftlint": "@ionic/swiftlint-config",

--- a/package.json
+++ b/package.json
@@ -1,9 +1,9 @@
 {
   "name": "appsflyer-capacitor-plugin",
-  "version": "6.16.2",
-  "iosSdkVersion": "6.16.2",
-  "androidSdkVersion": "6.16.2",
-  "buildNumber": "24",
+  "version": "6.17.0",
+  "iosSdkVersion": "6.17.0",
+  "androidSdkVersion": "6.17.0",
+  "buildNumber": "25",
   "description": "AppsFlyer SDK plugin for Capacitor",
   "main": "dist/plugin.cjs.js",
   "module": "dist/esm/index.js",
@@ -55,10 +55,10 @@
   "devDependencies": {
     "@angular/cli": "^12.1.1",
     "@babel/plugin-proposal-private-property-in-object": "^7.21.11",
-    "@capacitor/android": "^6.0.0",
-    "@capacitor/core": "^6.0.0",
+    "@capacitor/android": "^7.0.0",
+    "@capacitor/core": "^7.0.0",
     "@capacitor/docgen": "^0.2.0",
-    "@capacitor/ios": "^6.0.0",
+    "@capacitor/ios": "^7.0.0",
     "@ionic/eslint-config": "^0.4.0",
     "@ionic/prettier-config": "^1.0.1",
     "@ionic/swiftlint-config": "^1.1.2",
@@ -71,7 +71,7 @@
     "typescript": "~4.0.3"
   },
   "peerDependencies": {
-    "@capacitor/core": "^6.0.0"
+    "@capacitor/core": "^7.0.0"
   },
   "prettier": "@ionic/prettier-config",
   "swiftlint": "@ionic/swiftlint-config",

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -80,7 +80,7 @@ export interface AppsFlyerPlugin {
     logEvent(data: AFEvent): Promise<AFRes>
 
     /**
-     * Setting your own customer ID enables you to cross-reference your own unique ID with AppsFlyer’s unique ID and other devices’ IDs.
+     * Setting your own customer ID enables you to cross-reference your own unique ID with AppsFlyer's unique ID and other devices' IDs.
      * This ID is available in raw-data reports and in the Postback APIs for cross-referencing with your internal IDs.
      */
     setCustomerUserId(cuid: AFCuid): Promise<void>
@@ -285,4 +285,11 @@ export interface AppsFlyerPlugin {
      * @param options: AFConsentOptions that consists with all the possible options for consent collection, boolean params.
      */
     setConsentDataV2(options: AFConsentOptions): Promise<void>
+
+    /**
+     * Disables AppSet ID collection. If called before SDK init, App Set ID will not be collected.
+     * If called after init, App Set ID will be collected but not sent in request payloads.
+     * Android only.
+     */
+    disableAppSetId(): Promise<void>
 }


### PR DESCRIPTION
- Upgrading the native Android and iOS SDKs to version 6.17.0
- Adding support for the new Android API `disableAppSetId`, which prevents the SDK from collecting the AppSet ID when invoked by the app developer.
- Bumping the Capacitor framework version from v6 to v7 for compatibility.
- Update example project as well.