### PR TITLE
fix(ios): migrate unsafe NSLog logger to CAPLog

### DIFF
--- a/ios/Plugin/AppsFlyerPlugin.swift
+++ b/ios/Plugin/AppsFlyerPlugin.swift
@@ -950,8 +950,8 @@ extension AppsFlyerPlugin : DeepLinkDelegate{
     
 }
 
-extension AppsFlyerPlugin{
-    private func afLogger(msg : String){
-        NSLog ("AppsFlyer [Debug][Capacitor]: \(msg)");
+extension AppsFlyerPlugin {
+    private func afLogger(msg: String) {
+        CAPLog.print("⚡️ ", self.pluginId, "-", msg)
     }
 }


### PR DESCRIPTION
Replace raw NSLog usage in afLogger with Capacitor CAPLog.print.

The current logger receives deep-link and universal-link URLs, then passes the interpolated message directly to NSLog. Since NSLog treats the first argument as a format string, percent sequences in normal percent-encoded URLs can cause crashes during regular app usage.

This also has security relevance: custom scheme and universal-link URLs often contain sensitive values such as tokens or one-time parameters, and this plugin-level logging is currently not tied to the AppsFlyer SDK isDebug setting. In addition, externally controlled URL input can trigger the logging path, which makes crafted deep links a potential crash / denial-of-service vector.

Using CAPLog.print treats the message as log data instead of an NSLog format string, routes output through Capacitor's logging path, and follows the style used by official Capacitor iOS plugins.