### PR TITLE
feat: expose Android setOaidData API

### DIFF
--- a/android/src/main/java/capacitor/plugin/appsflyer/sdk/AppsFlyerPlugin.kt
+++ b/android/src/main/java/capacitor/plugin/appsflyer/sdk/AppsFlyerPlugin.kt
@@ -3,6 +3,7 @@ package capacitor.plugin.appsflyer.sdk
 import android.Manifest
 import android.content.Intent
 import android.util.Log
+import com.appsflyer.AppsFlyerLib
 import com.appsflyer.pluginbridge.handler.AppsFlyerRpcHandler
 import com.appsflyer.pluginbridge.model.RpcResponse
 import com.getcapacitor.JSObject
@@ -56,6 +57,8 @@ internal fun normalizeDeepLinkEvent(eventJson: String): String = parseJsonOrDefa
     envelope.toString()
 }
 
+internal fun isValidOaid(oaid: String?): Boolean = !oaid.isNullOrBlank()
+
 /** Capacitor bridge — every SDK capability is dispatched via executeRpc -> AppsFlyerRpcHandler. */
 @CapacitorPlugin(
     name = "AppsFlyerPlugin",
@@ -99,6 +102,17 @@ class AppsFlyerPlugin : Plugin() {
         }
         val executor = if (isAwaitResponseCall(requestJson)) awaitResponseExecutor else rpcExecutor
         dispatch(call, executor, requestJson)
+    }
+
+    @PluginMethod
+    fun setOaidData(call: PluginCall) {
+        val oaid = call.getString("oaid")
+        if (!isValidOaid(oaid)) {
+            call.reject("oaid is required and must not be blank", "INVALID_REQUEST")
+            return
+        }
+        AppsFlyerLib.getInstance().setOaidData(oaid)
+        call.resolve()
     }
 
     private fun dispatch(call: PluginCall, executor: ExecutorService, requestJson: String) {

--- a/android/src/test/java/capacitor/plugin/appsflyer/sdk/AppsFlyerPluginTest.kt
+++ b/android/src/test/java/capacitor/plugin/appsflyer/sdk/AppsFlyerPluginTest.kt
@@ -72,4 +72,16 @@ class AppsFlyerPluginTest {
         assertFalse(isAwaitResponseCall("""{"method":"setCustomerUserId","params":{}}"""))
         assertFalse(isAwaitResponseCall("""{"method":"performDeepLinking","params":{}}"""))
     }
+
+    @Test
+    fun `isValidOaid accepts a non-empty OAID`() {
+        assertTrue(isValidOaid("custom-oaid"))
+    }
+
+    @Test
+    fun `isValidOaid rejects missing empty and blank OAIDs`() {
+        assertFalse(isValidOaid(null))
+        assertFalse(isValidOaid(""))
+        assertFalse(isValidOaid("   "))
+    }
 }

--- a/docs/API.md
+++ b/docs/API.md
@@ -134,6 +134,7 @@ A platform value of "—" means the underlying native SDK has no equivalent call
 | [`setLogLevel`](#setloglevel) | ✅ | — |
 | [`setMinTimeBetweenSessions`](#setmintimebetweensessions) | ✅ | ✅ |
 | [`setOneLinkCustomDomain`](#setonelinkcustomdomain) | ✅ | ✅ |
+| [`setOaidData`](#setoaiddata) | ✅ | — |
 | [`setOutOfStore`](#setoutofstore) | ✅ | — |
 | [`setPartnerData`](#setpartnerdata) | ✅ | ✅ |
 | [`setPluginInfo`](#setplugininfo-internal) | ✅ | ✅ |
@@ -924,6 +925,26 @@ import { Capacitor } from '@capacitor/core';
 if (Capacitor.getPlatform() === 'android') {
   await AppsFlyer.setDisableNetworkData({ isDisable: true });
 }
+```
+
+#### setOaidData
+
+`setOaidData(params) : Promise<void>` — Android only
+
+Supplies an OAID retrieved by the application using a custom OAID provider. Call this method
+before [`init()`](#init). The `oaid` value must be a non-blank string.
+
+| parameter | type | description |
+| --- | --- | --- |
+| oaid | string | OAID retrieved by the application |
+
+```typescript
+import { Capacitor } from '@capacitor/core';
+
+if (Capacitor.getPlatform() === 'android') {
+  await AppsFlyer.setOaidData({ oaid: customOaid });
+}
+await AppsFlyer.init({ devKey: 'K2***********99', appId: '41*****44' });
 ```
 
 #### performDeepLinking

--- a/src/__tests__/capacitor-transport.test.ts
+++ b/src/__tests__/capacitor-transport.test.ts
@@ -3,26 +3,37 @@ import { describe, expect, it, vi, beforeEach } from 'vitest';
 
 import { AppsFlyerRpcError, CapacitorTransport } from '../capacitor-transport';
 
-const { executeRpc, addListener } = vi.hoisted(() => ({
+const { executeRpc, setOaidData, addListener } = vi.hoisted(() => ({
   executeRpc: vi.fn(),
+  setOaidData: vi.fn(),
   addListener: vi.fn(),
 }));
 
 // vi.mock is hoisted above all imports by Vitest, regardless of where it's written in the file.
 vi.mock('@capacitor/core', () => ({
   Capacitor: { getPlatform: () => 'android' },
-  registerPlugin: () => ({ executeRpc, addListener }),
+  registerPlugin: () => ({ executeRpc, setOaidData, addListener }),
 }));
 
 describe('CapacitorTransport', () => {
   beforeEach(() => {
     executeRpc.mockReset();
+    setOaidData.mockReset();
     addListener.mockReset();
   });
 
   it('reports the Capacitor platform', () => {
     const transport = new CapacitorTransport();
     expect(transport.platform).toBe('android');
+  });
+
+  it('forwards OAID data to the native Capacitor method', async () => {
+    setOaidData.mockResolvedValue(undefined);
+    const transport = new CapacitorTransport();
+
+    await transport.setOaidData({ oaid: 'custom-oaid' });
+
+    expect(setOaidData).toHaveBeenCalledWith({ oaid: 'custom-oaid' });
   });
 
   it('does not throw on construction when Capacitor.getPlatform() returns web', () => {

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -1,7 +1,8 @@
 import { describe, expect, it, vi } from 'vitest';
 
-const { AppsFlyerSDKMock } = vi.hoisted(() => ({
+const { AppsFlyerSDKMock, setOaidData } = vi.hoisted(() => ({
   AppsFlyerSDKMock: vi.fn(),
+  setOaidData: vi.fn(),
 }));
 
 vi.mock('@appsflyer-sdk/js-core-plugin', () => ({
@@ -10,7 +11,7 @@ vi.mock('@appsflyer-sdk/js-core-plugin', () => ({
 
 vi.mock('@capacitor/core', () => ({
   Capacitor: { getPlatform: () => 'android' },
-  registerPlugin: () => ({ executeRpc: vi.fn(), addListener: vi.fn() }),
+  registerPlugin: () => ({ executeRpc: vi.fn(), setOaidData, addListener: vi.fn() }),
 }));
 
 describe('index', () => {
@@ -29,5 +30,14 @@ describe('index', () => {
   it('exports the same instance as both the named and default export', async () => {
     const indexModule = await import('../index');
     expect(indexModule.default).toBe(indexModule.AppsFlyer);
+  });
+
+  it('exposes setOaidData on the public AppsFlyer instance', async () => {
+    setOaidData.mockResolvedValue(undefined);
+    const { AppsFlyer } = await import('../index');
+
+    await AppsFlyer.setOaidData({ oaid: 'custom-oaid' });
+
+    expect(setOaidData).toHaveBeenCalledWith({ oaid: 'custom-oaid' });
   });
 });

--- a/src/__tests__/public-types.smoke.ts
+++ b/src/__tests__/public-types.smoke.ts
@@ -13,6 +13,7 @@ import type {
   PluginIdentity,
   RpcEvent,
   RpcTransport,
+  SetOaidDataOptions,
 } from '../index';
 
 // Referencing each type keeps `noUnusedLocals`/import-elision from silently dropping the check.
@@ -26,4 +27,5 @@ export type PublicTypesSmokeTest = [
   PluginIdentity,
   RpcEvent,
   RpcTransport,
+  SetOaidDataOptions,
 ];

--- a/src/capacitor-transport.ts
+++ b/src/capacitor-transport.ts
@@ -6,6 +6,7 @@ const RPC_EVENT_NAME = 'rpcEvent';
 // The only shape the native side needs to expose; kept private since it has one caller (CapacitorTransport).
 interface AppsFlyerNativePlugin {
   executeRpc(options: { requestJson: string }): Promise<{ responseJson: string }>;
+  setOaidData(options: { oaid: string }): Promise<void>;
   addListener(
     eventName: typeof RPC_EVENT_NAME,
     listenerFunc: (event: { envelopeJson: string }) => void,
@@ -56,6 +57,10 @@ export class CapacitorTransport implements RpcTransport {
       throw new AppsFlyerRpcError(parsed.error.code, parsed.error.message);
     }
     return (parsed as RpcSuccess<T>).data;
+  }
+
+  setOaidData(options: { oaid: string }): Promise<void> {
+    return AppsFlyerNative.setOaidData(options);
   }
 
   // Guards against a second native listener: two would each dispatch every RPC event once,

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,10 +8,24 @@ export * from '@appsflyer-sdk/js-core-plugin';
 // js-core-plugin does not export AFPurchaseType/MediationNetwork equivalents (Task 1 finding).
 export * from './constants';
 
-const AppsFlyer = new AppsFlyerSDK(new CapacitorTransport(), {
-  plugin: 'capacitor',
-  pluginVersion: version,
-});
+export interface SetOaidDataOptions {
+  oaid: string;
+}
+
+class AppsFlyerCapacitorSDK extends AppsFlyerSDK {
+  constructor(private readonly capacitorTransport: CapacitorTransport) {
+    super(capacitorTransport, {
+      plugin: 'capacitor',
+      pluginVersion: version,
+    });
+  }
+
+  setOaidData(options: SetOaidDataOptions): Promise<void> {
+    return this.capacitorTransport.setOaidData(options);
+  }
+}
+
+const AppsFlyer = new AppsFlyerCapacitorSDK(new CapacitorTransport());
 
 export { AppsFlyer };
 export default AppsFlyer;


### PR DESCRIPTION
## Summary

- expose `AppsFlyer.setOaidData({ oaid })` in the public TypeScript API
- delegate to Android SDK `AppsFlyerLib.getInstance().setOaidData(oaid)`
- reject missing, empty, or blank OAID values using the plugin's `INVALID_REQUEST` pattern
- document the API and add focused TypeScript and Android tests

This enables applications using custom OAID providers to retrieve the OAID themselves and supply it to AppsFlyer before SDK initialization, as documented in the [AppsFlyer OAID guide](https://dev.appsflyer.com/hc/docs/oaid).

## Platform support

This method is Android-only. No iOS behavior is introduced; unsupported platforms continue to reject through Capacitor's existing unimplemented-method behavior.

## Testing

- `npm run fmt` (ESLint and Prettier completed; SwiftLint was unavailable locally and no Swift files changed)
- `npm run eslint`
- `npm run prettier -- --check`
- `npm test`
- `npm run build`
- Android `gradle clean build test --no-daemon` with Gradle 8.14.3

The exact Android API signature was verified against the pinned `com.appsflyer:af-android-sdk:7.0.1` AAR: `public abstract void setOaidData(java.lang.String)`.